### PR TITLE
Document rewrite engine and fix gradient test

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -9,6 +9,7 @@
 
 - **Single, tiny IR** for math expressions built with normal C++ operators (expression templates).
 - **Symbolic AD** that returns an expression tree, so the same infrastructure can compile the gradient to any backend.
+- **Algebraic rewrite system** for normalization and rule-based simplification.
 - **Modularity by construction:** add an operation (`Op`) once; evaluation, AD, simplification, and all backends see it with minimal glue.
 - **No runtime polymorphism** in the IR. Nodes are simple templates; composition is resolved at compile-time.
 - **Backend plug-ins** via a single `compile(expr, backend)` visitor function. Backends implement `emitVar`, `emitConst`, `emitApply` overloads.
@@ -23,6 +24,12 @@ Trade-off: a templated IR yields large types and deep instantiations. We mitigat
 ```
 include/et/expr.hpp            # Core IR, ops, evaluation, AD, compile visitor, Vars, grad helpers
 include/et/simplify.hpp        # Tiny algebraic simplifier (constant folding + neutral/annihilator rules)
+include/et/runtime_ast.hpp     # Runtime AST backing the rewrite system
+include/et/normalize.hpp       # AC normalization utilities for Add/Mul
+include/et/pattern.hpp         # Pattern DSL for rewrite rules
+include/et/match.hpp           # Structural matcher with placeholders
+include/et/rewrite.hpp         # Fixed-point rewrite driver
+include/et/rules_default.hpp   # Built-in rule set (neutral, trig, etc.)
 include/et/tape_backend.hpp    # Reverse-mode tape backend (forward eval + VJP gradient)
 include/et/torch_jit_backend.hpp  # TorchScript backend (optional; -DET_WITH_TORCH)
 examples/                      # Small programs exercising the API and backends
@@ -252,6 +259,9 @@ If you need cross-type unification (e.g., `int` + `double` → `double`), prefer
 - **03_simplify.cpp** — Simplify the derivative and evaluate.
 - **04_tape_ad.cpp** — Compile to a reverse-mode tape and compute value + gradient via VJP.
 - **05_torchjit.cpp** — (Optional) Lower the expression to a TorchScript graph and print it.
+- **06_ops_and_cse.cpp** — Add new operations and exercise structural CSE.
+- **07_hash_cse.cpp** — Faster hash-based CSE variant.
+- **08_rewrite_rules.cpp** — Algebraic rewrite rules and normalization.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ Vibex is a **header-only C++ expression template engine** for building, simplify
 - **Template-driven expression building** — fully type-safe and constexpr-friendly
 - **Compile-time constant folding** to eliminate trivial work before runtime
 - **Common Subexpression Elimination (CSE)** — both structural and hash-based
+- **Algebraic rewrite system** — rule-based simplification over a normalized runtime AST
 - **Backend-agnostic compilation** — output to tapes, evaluators, or your own executor
 - **Operator overloading limited to ET nodes** — no pollution of unrelated types
 
 Whether you’re building a symbolic math library, optimizing DSLs, or just want to see how far you can push C++ metaprogramming without losing your mind, Vibex keeps the vibes high and the compile times… reasonable.
+
+See `DESIGN_REWRITE.md` for details on the rewrite engine and `examples/08_rewrite_rules.cpp` for a live demo.

--- a/USAGE.md
+++ b/USAGE.md
@@ -96,6 +96,16 @@ auto g = simplify(dfx);      // returns an ET node (possibly with Const folded)
 auto v = g(2.4, 6, 1.1);
 ```
 
+For aggressive canonicalization and algebraic identities, use the rewrite engine:
+
+```cpp
+auto r = rewrite(f, default_rules());
+```
+
+It normalizes associative/commutative ops and applies pattern-based rules
+like neutral elements and trig identities (see `DESIGN_REWRITE.md` and
+`examples/08_rewrite_rules.cpp`).
+
 ---
 
 ## 4) Backends & Visitors

--- a/tests/test_core.cpp
+++ b/tests/test_core.cpp
@@ -94,13 +94,19 @@ int main() {
     }
 
     // Finite-difference cross-check for all partials
-    std::vector<double> in = {1.2, 2.0, 0.3};
-    double fd_gx = fd_partial3(f, in, 0);
-    double fd_gy = fd_partial3(f, in, 1);
-    double fd_gz = fd_partial3(f, in, 2);
-    assert(approx(grad[0], fd_gx, 1e-6));
-    assert(approx(grad[1], fd_gy, 1e-6));
-    assert(approx(grad[2], fd_gz, 1e-6));
+    {
+      TapeBackend tb(3);
+      int root = compile_hash_cse(f, tb);
+      tb.tape.output_id = root;
+      std::vector<double> in = {1.2, 2.0, 0.3};
+      auto gvec = tb.tape.backward(in);
+      double fd_gx = fd_partial3(f, in, 0);
+      double fd_gy = fd_partial3(f, in, 1);
+      double fd_gz = fd_partial3(f, in, 2);
+      assert(approx(gvec[0], fd_gx, 1e-6));
+      assert(approx(gvec[1], fd_gy, 1e-6));
+      assert(approx(gvec[2], fd_gz, 1e-6));
+    }
   }
 
   // 5) CSE sanity: sin(x) + sin(x) compiles shared subexprs


### PR DESCRIPTION
## Summary
- fix gradient finite difference check in core tests
- document algebraic rewrite system in README, USAGE, and DESIGN docs

## Testing
- `cmake --build build`
- `ctest --test-dir build -V`


------
https://chatgpt.com/codex/tasks/task_b_689a75dd420c8330be511c092077c66c