### PR TITLE
Fix AC matcher backtracking and normalize const order

### DIFF
--- a/include/et/match.hpp
+++ b/include/et/match.hpp
@@ -47,10 +47,13 @@ inline bool match_ac(const RGraph& g, const RNode& n, const pat::Pattern& p, Bin
       auto b_snapshot = b; auto mb_snapshot = mb;
       if (match_node(g, cand, pc, b, mb)) {
         // consume cand
-        int last = remaining.back(); remaining[r] = last; remaining.pop_back();
+        int last = remaining.back();
+        remaining[r] = last;
+        remaining.pop_back();
         if (dfs(i+1)) return true;
         // backtrack
-        remaining.push_back(last); // restore size; position will be re-evaluated safely as we return
+        remaining.push_back(last);
+        remaining[r] = cand;
       }
       b = std::move(b_snapshot); mb = std::move(mb_snapshot);
     }

--- a/include/et/normalize.hpp
+++ b/include/et/normalize.hpp
@@ -42,7 +42,16 @@ struct ChildKey {
 };
 
 inline bool child_less(const ChildKey& a, const ChildKey& b) {
-  if (a.kind != b.kind) return a.kind < b.kind;
+  auto rank = [](NodeKind k) {
+    switch (k) {
+      case NodeKind::Const: return 0;
+      case NodeKind::Var:   return 1;
+      default:              return 2 + static_cast<int>(k);
+    }
+  };
+  int ra = rank(a.kind);
+  int rb = rank(b.kind);
+  if (ra != rb) return ra < rb;
   if (a.h != b.h) return a.h < b.h;
   return a.id < b.id;
 }


### PR DESCRIPTION
## Summary
- Ensure AC pattern matching restores consumed candidates during backtracking
- Order constants before variables during normalization for canonical Mul/ Add terms

## Testing
- `ctest --test-dir build -V`

------
https://chatgpt.com/codex/tasks/task_b_689ab80611588330844fcfe8b4305ee5